### PR TITLE
bug fix 0.5 multiplication

### DIFF
--- a/orbit_determination/ekf.py
+++ b/orbit_determination/ekf.py
@@ -108,7 +108,7 @@ class EKF:
         x_new = f(x, self.dt)
 
         self.q_p = left_q(self.q_m) @ quaternion.as_float_array(
-            quaternion.from_rotation_vector(0.5 * self.dt * w)
+            quaternion.from_rotation_vector(self.dt * w)
         )
 
         self.r_p = x_new[0:3]
@@ -116,7 +116,7 @@ class EKF:
 
         # A_att = self.H.T @ left_q(self.q_p).T @ left_q(self.q_m) @ right_q(quaternion.as_float_array(
         # quaternion.from_rotation_vector(self.w))) @ self.H
-        A_att = quaternion.as_rotation_matrix(quaternion.from_rotation_vector(-0.5 * self.dt * w))
+        A_att = quaternion.as_rotation_matrix(quaternion.from_rotation_vector(-1 * self.dt * w))
 
         A = np.block([[A_pos, np.zeros((6, 3))], [np.zeros((3, 6)), A_att]])
 

--- a/orbit_determination/test_ekf.py
+++ b/orbit_determination/test_ekf.py
@@ -74,7 +74,7 @@ def run_simulation() -> None:
 
     config = load_config()
     # Set the world update rate and mission duration to a rate that is workable for testing
-    config["solver"]["world_update_rate"] = 1 / 4  # Hz
+    config["solver"]["world_update_rate"] = 1 / 3  # Hz
     config["mission"]["duration"] = 3 * 90 * 20  # s
 
     dt = 1 / config["solver"]["world_update_rate"]
@@ -91,20 +91,20 @@ def run_simulation() -> None:
     data_manager.push_next_state(initial_state, init_rot)
 
     # Set the number of update iterations for the IEKF
-    num_iter = 3
+    num_iter = 4
 
     # Fix a constant rotation velocity for the test.
-    rot = np.array([0, 0, np.pi / 4])
+    rot = np.array([0, 0, np.pi / 18])
 
     # Initialize IMU and EKF
     imu = imu_init(dt)
     ekf = EKF(
         # TODO: Apply initial error to quaternion initialization
         # error ranges are in meters and m/s
-        r=initial_state[0:3] + np.random.normal(0, 5000, 3),
-        v=initial_state[3:6] + np.random.normal(0, 5000, 3),
+        r=initial_state[0:3] + np.random.normal(0, 800, 3),
+        v=initial_state[3:6] + np.random.normal(0, 10, 3),
         q=quaternion.as_float_array(quaternion.from_rotation_matrix(init_rot)),
-        P=np.eye(9) * 100,
+        P=np.eye(9) * 10,
         Q=np.eye(9) * 1e-12,
         R_vec=np.zeros((3, 3)),
         dt=dt,
@@ -123,7 +123,7 @@ def run_simulation() -> None:
 
         next_state = f(x, dt)
         next_quat = quaternion.from_rotation_matrix(q) * quaternion.from_rotation_vector(
-            w * dt * 0.5
+            w * dt
         )
 
         data_manager.push_next_state(next_state, quaternion.as_rotation_matrix(next_quat))
@@ -133,7 +133,7 @@ def run_simulation() -> None:
         gyro_meas, _ = imu.update(w, np.zeros((3)))
         ekf.predict(u=gyro_meas)
 
-        if t % 3 == 0:
+        if t % 5 == 0:
             for camera_name in CameraModelManager.CAMERA_NAMES:
                 data_manager.take_measurement(
                     landmark_bearing_sensor, camera_model_manager[camera_name]


### PR DESCRIPTION
The quaternion function `from_rotation_vector` already multiplies by 0.5 so the 0.5 is not needed in the code. 
[see source here](https://quaternion.readthedocs.io/en/latest/quaternion/#quaternion.from_rotation_vector)
Parameters have been adjusted to yield a non-divergent result