### PR TITLE
Bearing Sensor for stored measurements

### DIFF
--- a/orbit_determination/landmark_bearing_sensors.py
+++ b/orbit_determination/landmark_bearing_sensors.py
@@ -363,4 +363,4 @@ class SimulatedMLStoredLandmarkBearingSensor(LandmarkBearingSensor):
         eci_R_body: np.ndarray,
         camera_model: CameraModel,
     ) -> Tuple[np.ndarray, np.ndarray]:
-        return 0
+        raise NotImplementedError("The take_measurement method is not implemented and shouldn't be used.")

--- a/orbit_determination/landmark_bearing_sensors.py
+++ b/orbit_determination/landmark_bearing_sensors.py
@@ -331,3 +331,36 @@ class SimulatedMLLandmarkBearingSensor(LandmarkBearingSensor):
 
         # TODO: output confidences too
         return bearing_unit_vectors_body, landmark_positions_eci
+
+
+class SimulatedMLStoredLandmarkBearingSensor(LandmarkBearingSensor):
+    """
+    A sensor that uses already calculated landmark bearing measurements and landmark locations to provide correct measurements at each timestep.
+    """
+
+    def __init__(self, name) -> None:
+        # Set up paths to stored data
+        VIS_INF_DIR = "vis_inf"
+        self.bearing_dir = os.path.join("output_dir", name, VIS_INF_DIR, "bearing_vectors")
+
+    def load_measurements(self, timestep, camera_name):
+        # Load the bearing vectors and landmark positions from the stored data
+        base_name = f"{timestep}_{camera_name}"
+        file_path = os.path.join(self.bearing_dir, f"landmarks_{base_name}.npz")
+        with np.load(file_path) as data:
+            bearing_vectors = data["bearing_vectors"]
+            landmark_positions = data["landmark_positions"]
+
+        if bearing_vectors.ndim == 1:
+            bearing_vectors = np.expand_dims(bearing_vectors, axis=0)
+            landmark_positions = np.expand_dims(landmark_positions, axis=0)
+        return bearing_vectors, landmark_positions
+
+    def take_measurement(
+        self,
+        epoch: Epoch,
+        cubesat_position: np.ndarray,
+        eci_R_body: np.ndarray,
+        camera_model: CameraModel,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        return 0

--- a/orbit_determination/od_simulation_data_manager.py
+++ b/orbit_determination/od_simulation_data_manager.py
@@ -9,7 +9,10 @@ from typing import Tuple
 import numpy as np
 from brahe.epoch import Epoch
 
-from orbit_determination.landmark_bearing_sensors import LandmarkBearingSensor
+from orbit_determination.landmark_bearing_sensors import (
+    LandmarkBearingSensor,
+    SimulatedMLStoredLandmarkBearingSensor,
+)
 from sensors.camera_model import CameraModel
 from utils.brahe_utils import increment_epoch
 
@@ -158,9 +161,14 @@ class ODSimulationDataManager:
         position_eci = self.states[t_idx, :3]
         eci_R_body = self.eci_Rs_body[t_idx, ...]
 
-        bearing_unit_vectors, landmarks = landmark_bearing_sensor.take_measurement(
-            self.latest_epoch, position_eci, eci_R_body, camera_model
-        )
+        if isinstance(landmark_bearing_sensor, SimulatedMLStoredLandmarkBearingSensor):
+            bearing_unit_vectors, landmarks = landmark_bearing_sensor.load_measurements(
+                t_idx - 1, camera_model.camera_name
+            )
+        else:
+            bearing_unit_vectors, landmarks = landmark_bearing_sensor.take_measurement(
+                self.latest_epoch, position_eci, eci_R_body, camera_model
+            )
         measurement_count = bearing_unit_vectors.shape[0]
         assert landmarks.shape[0] == measurement_count
 

--- a/scripts/run_ekf.py
+++ b/scripts/run_ekf.py
@@ -51,6 +51,7 @@ from orbit_determination.ekf import EKF
 from orbit_determination.landmark_bearing_sensors import (
     GroundTruthLandmarkBearingSensor,
     SimulatedMLLandmarkBearingSensor,
+    SimulatedMLStoredLandmarkBearingSensor,
 )
 from orbit_determination.od_simulation_data_manager import ODSimulationDataManager
 from sensors.camera_model import CameraModelManager
@@ -118,7 +119,7 @@ def run_simulation(args) -> None:
     starting_epoch = Epoch(*brahe.time.mjd_to_caldate(config["mission"]["start_date"]))
     N = int(np.ceil(config["mission"]["duration"] / dt))  # number of time steps in the simulation
 
-    landmark_bearing_sensor = GroundTruthLandmarkBearingSensor()
+    landmark_bearing_sensor = SimulatedMLStoredLandmarkBearingSensor(args.name)
     camera_model_manager = CameraModelManager()
     data_manager = ODSimulationDataManager(starting_epoch, dt)
 


### PR DESCRIPTION
Add new bearing sensor to loaded measurements from simulated ML measurements as outputted by the `run_vision.py` script.
Not really the cleanest way because we have to implement the take_measurement function as it's abstracted in the parent but we also cannot not implement it because the data manager expects the class to be of type landmarkbearingsensor.

solves #146 