### PR TITLE
Replace MemoryAwareProcessPool with standard multiprocessing

### DIFF
--- a/VisionTrainingGround/DataPipeline/generate_training_data.py
+++ b/VisionTrainingGround/DataPipeline/generate_training_data.py
@@ -5,7 +5,6 @@ This script will generate/overwrite the following contents in the training direc
 - /training_directory
   - /{region}
     - 00000.png
-    - 00000_mgrs_regions.npy
     - 00000_lat_lon.npy
     - ...
 """

--- a/VisionTrainingGround/DataPipeline/generate_training_data.py
+++ b/VisionTrainingGround/DataPipeline/generate_training_data.py
@@ -14,8 +14,7 @@ import argparse
 import os
 from functools import partial
 from itertools import product
-from multiprocessing import cpu_count
-from time import time
+from multiprocessing import cpu_count, Pool
 
 import cv2
 import numpy as np
@@ -27,7 +26,7 @@ from image_simulation.earth_vis import EarthImageSimulator, GeoTIFFCache
 from sensors.camera_model import CameraModel, CameraModelManager
 from utils.config_utils import USER_CONFIG_PATH, load_config
 from utils.earth_utils import get_MGRS_grid, get_nadir_rotation, lat_lon_to_ecef
-from utils.memory_aware_process_pool import MemoryAwareProcessPool
+from utils.function_utils import unpack_and_call
 
 LAT_LON_OUTPUT_FILE_SUFFIX = "_lat_lon.npz"
 
@@ -314,18 +313,25 @@ def main() -> None:
         off_nadir_variation=args.off_nadir_variation,
     )
     if args.num_processes > 1:
-        requests = list(requests_generator)
-        log_file_path = os.path.join(training_dir, f"training_data_generation_log_{time()}.csv")
-        with MemoryAwareProcessPool(num_workers=args.num_processes) as pool:
-            successful_requests, request_results = pool.map(
-                func, requests, output_log_path=log_file_path
+        with Pool(args.num_processes) as pool:
+            list(
+                tqdm(
+                    pool.imap_unordered(
+                        partial(
+                            unpack_and_call,
+                            func,
+                        ),
+                        requests_generator,
+                        chunksize=1,
+                    ),
+                    total=total_images,
+                    desc="Generating images",
+                )
             )
-
-        for request, success, result in zip(requests, successful_requests, request_results):
-            if not success:
-                print(f"Generation of training image for {request} failed with exception: {result}")
     else:
-        for region, file_prefix in tqdm(requests_generator, total=total_images):
+        for region, file_prefix in tqdm(
+            requests_generator, total=total_images, desc="Generating images"
+        ):
             func(region, file_prefix)
 
 

--- a/scripts/run_earth_vis.py
+++ b/scripts/run_earth_vis.py
@@ -26,18 +26,19 @@ import json
 import os
 from argparse import ArgumentParser
 from functools import partial
-from multiprocessing import cpu_count
+from multiprocessing import cpu_count, Pool
 
 import brahe
 import cv2
 import numpy as np
 from brahe.epoch import Epoch
+from tqdm import tqdm
 
 from image_simulation.earth_vis import EarthImageSimulator
 from sensors.camera_model import CameraModelManager
 from utils.brahe_utils import increment_epoch
 from utils.config_utils import USER_CONFIG_PATH, load_config
-from utils.memory_aware_process_pool import MemoryAwareProcessPool
+from utils.function_utils import unpack_and_call
 
 
 def parse_args() -> ArgumentParser:
@@ -150,10 +151,18 @@ def image_vis(args) -> None:
             for camera_name in CameraModelManager.CAMERA_NAMES:
                 requests.append((position_ecef, attitude_gt[i], camera_name, i))
 
-    with MemoryAwareProcessPool(num_workers=args.num_processes) as pool:
-        pool.map(
-            partial(generate_image, output_dir=f"{output_dir}/images"),
-            requests,
+    func = partial(generate_image, output_dir=f"{output_dir}/images")
+    with Pool(args.num_processes) as pool:
+        list(
+            tqdm(
+                pool.imap_unordered(
+                    partial(unpack_and_call, func),
+                    requests,
+                    chunksize=1,
+                ),
+                total=len(requests),
+                desc="Generating images",
+            )
         )
 
 

--- a/utils/function_utils.py
+++ b/utils/function_utils.py
@@ -1,0 +1,17 @@
+from typing import Callable, TypeVar, ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def unpack_and_call(func: Callable[P, R], args: P.args) -> R:
+    """
+    Unpacks the arguments, calls the provided function with those arguments, and returns the result.
+
+    Args:
+        func: The function to call.
+        args: An iterable of positional arguments to unpack.
+
+    Returns:
+        The result of calling the function with the unpacked arguments.
+    """
+    return func(*args)

--- a/utils/memory_aware_process_pool.py
+++ b/utils/memory_aware_process_pool.py
@@ -3,6 +3,7 @@ from multiprocessing import Array, Process, Queue
 from multiprocessing.sharedctypes import SynchronizedArray
 from time import perf_counter, sleep
 from typing import Callable, List, ParamSpec, Tuple, TypeVar
+from deprecated import deprecated
 
 import numpy as np
 import psutil
@@ -12,6 +13,11 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+@deprecated(
+    reason="After some bug fixes, the memory usage when generating images with the image simulator is now low enough "
+           "that we are bottlenecked by the CPU. As a result, this class is no longer needed. Also, there is likely a "
+           "memory leak in this class leading to gradual performance degradation over time.",
+)
 class MemoryAwareProcessPool:
     """
     This class maintains a pool of worker processes to execute jobs in parallel. The number of jobs running in parallel


### PR DESCRIPTION
After the bug fix in PR #145, memory usage is now below the workstation's RAM even when maxing out the CPU. As a result, the code changes in `MemoryAwareProcessPool` are now overkill. This PR switches to using standard `multiprocessing.Pool` which works much better now.