### PR TITLE
Properly close npz file handle

### DIFF
--- a/VisionTrainingGround/DataPipeline/generate_training_data.py
+++ b/VisionTrainingGround/DataPipeline/generate_training_data.py
@@ -95,9 +95,8 @@ class GeotaggedImage:
         image = cv2.imread(os.path.join(region_dir, f"{file_prefix}{GeotaggedImage.IMAGE_SUFFIX}"))
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
-        lat_lon = np.load(
-            os.path.join(region_dir, f"{file_prefix}{GeotaggedImage.LAT_LON_SUFFIX}")
-        )["lat_lon"]
+        with np.load(os.path.join(region_dir, f"{file_prefix}{GeotaggedImage.LAT_LON_SUFFIX}")) as data:
+            lat_lon = data["lat_lon"]
 
         geotagged_image = GeotaggedImage(image, lat_lon)
         geotagged_image.assert_invariants()


### PR DESCRIPTION
We suspect that the [leaked file descriptors](https://numpy.org/doc/2.2/reference/generated/numpy.load.html#:~:text=Data%20stored%20in%20the%20file.%20For%20.npz%20files%2C%20the%20returned%20instance%20of%20NpzFile%20class%20must%20be%20closed%20to%20avoid%20leaking%20file%20descriptors.) caused by this bug were the root cause of the gradual slowdown in performance over time that we saw in various.