### PR TITLE
Allow resuming progress in prepare_yolo_data.py

### DIFF
--- a/VisionTrainingGround/DataPipeline/generate_training_data.py
+++ b/VisionTrainingGround/DataPipeline/generate_training_data.py
@@ -5,7 +5,7 @@ This script will generate/overwrite the following contents in the training direc
 - /training_directory
   - /{region}
     - 00000.png
-    - 00000_lat_lon.npy
+    - 00000_lat_lon.npz
     - ...
 """
 

--- a/VisionTrainingGround/LD/prepare_yolo_data.py
+++ b/VisionTrainingGround/LD/prepare_yolo_data.py
@@ -483,7 +483,7 @@ def main():
                         partial(unpack_and_call, generate_yolo_label), get_requests_generator()
                     ),
                     total=total_requests,
-                    desc="Generating images",
+                    desc="Generating YOLO label files",
                 )
             )
     else:

--- a/VisionTrainingGround/LD/prepare_yolo_data.py
+++ b/VisionTrainingGround/LD/prepare_yolo_data.py
@@ -30,16 +30,18 @@ This scipy will generate/overwrite the following contents in the training direct
 import argparse
 import os
 from functools import partial
+from itertools import starmap
 from multiprocessing import Pool, cpu_count
-from typing import List
+from typing import Generator, List, Tuple
 
 import cv2
 import numpy as np
-from tqdm import tqdm
 import yaml
+from tqdm import tqdm
 
 from utils.config_utils import USER_CONFIG_PATH, load_config
 from utils.earth_utils import lat_lon_to_ecef
+from utils.function_utils import unpack_and_call
 from vision_inference.landmark_detector import LandmarkDetector
 from VisionTrainingGround.DataPipeline.generate_training_data import GeotaggedImage
 from VisionTrainingGround.LD.run_saliency_analysis import get_common_file_name_prefixes
@@ -47,6 +49,7 @@ from VisionTrainingGround.LD.select_bounding_boxes import BOUNDING_BOXES_VISUALI
 
 LD_TRAINING_DIR_NAME = "LD_training"
 YOLO_CONFIG_FILE_NAME = "dataset.yaml"
+SPLIT_DIR_NAMES = ["train", "test", "val"]
 
 
 def parse_args() -> argparse.Namespace:
@@ -79,6 +82,11 @@ def parse_args() -> argparse.Namespace:
         help="Whether to overwrite the output directory if it exists.",
     )
     parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Whether to resume preparing yolo data for all requests that failed in the previous run.",
+    )
+    parser.add_argument(
         "--num_processes",
         type=int,
         default=int(0.8 * cpu_count()),
@@ -101,51 +109,147 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def setup_LD_training_directory(LD_training_dir: str, overwrite: bool) -> bool:
+def setup_LD_training_directory(
+    region_id: str, overwrite: bool, resume: bool, test_fraction: float, val_fraction: float
+) -> bool:
     """
-    Create the LD_training directory if it does not exist, or clear the output files that will be replaced if overwrite
-    is True.
+    Set up the LD_training directory for the prepared YOLO training data.
+    This includes creating the directories, writing the dataset.yaml file, performing the train/test/val split, and
+    creating symlinks to the image files.
 
-    :param LD_training_dir: The path to the LD_training directory.
-    :param overwrite: Whether to overwrite the output files if they exist.
-    :return: True if LD_training is now a directory that doesn't contain any of the output files that would be replaced,
-             False otherwise.
+    :param region_id: The MGRS region ID to set up the LD_training directory for.
+    :param overwrite: Whether to overwrite the output files if they exist. Cannot be True if resume is also True.
+    :param resume: Whether to resume preparing YOLO data for all requests that failed in the previous run. Cannot be
+                   True if overwrite is also True.
+    :param test_fraction: The fraction of images to use for testing.
+    :param val_fraction: The fraction of images to use for validation.
+    :return: True if LD_training is now a directory that is ready for preparing YOLO training data, False otherwise.
     """
+    assert not (resume and overwrite), "resume and overwrite cannot be used together."
+    train_fraction = 1 - test_fraction - val_fraction
+    assert 0 <= train_fraction <= 1, "test_fraction + val_fraction must be less than or equal to 1."
+    assert 0 <= test_fraction <= 1, "test_fraction must be in the range [0, 1]."
+    assert 0 <= val_fraction <= 1, "val_fraction must be in the range [0, 1]."
+
+    training_dir = load_config(USER_CONFIG_PATH)["training_directory"]
+    LD_training_dir = os.path.join(training_dir, region_id, LD_TRAINING_DIR_NAME)
+
     if not os.path.exists(LD_training_dir):
-        os.makedirs(LD_training_dir)
+        os.makedirs(LD_training_dir, exist_ok=True)
 
     if not os.path.isdir(LD_training_dir):
         if not overwrite:
             return False
         os.remove(LD_training_dir)
-        os.makedirs(LD_training_dir)
+        os.makedirs(LD_training_dir, exist_ok=True)
 
     yolo_config_path = os.path.join(LD_training_dir, YOLO_CONFIG_FILE_NAME)
-    if os.path.exists(yolo_config_path):
-        if not overwrite:
+    write_yolo_config = False
+    if not os.path.exists(yolo_config_path):
+        write_yolo_config = True
+    else:
+        if not overwrite and not resume:
             return False
-        os.remove(yolo_config_path)
+        if overwrite:
+            os.remove(yolo_config_path)
+            write_yolo_config = True
 
-    for split_dir_name in ["train", "test", "val"]:
+    if write_yolo_config:
+        bounding_boxes_lat_lon = LandmarkDetector.load_ground_truth(
+            os.path.join(
+                training_dir, LandmarkDetector.get_region_bounding_boxes_relative_path(region_id)
+            )
+        )
+        num_classes = bounding_boxes_lat_lon.shape[0]
+        yolo_config = {
+            "path": os.path.abspath(LD_training_dir),
+            "train": "train/images",
+            "test": "test/images",
+            "val": "val/images",
+            "nc": num_classes,
+            "names": [str(i) for i in range(num_classes)],
+        }
+
+        with open(yolo_config_path, "w", encoding="utf-8") as yolo_config_file:
+            yaml.dump(yolo_config, yolo_config_file, default_flow_style=False)
+
+    split_img_file_names_list: List[List[str]] = []
+    split_label_file_names_list: List[List[str]] = []
+    for split_dir_name in SPLIT_DIR_NAMES:
         split_dir = os.path.join(LD_training_dir, split_dir_name)
+        images_dir = os.path.join(split_dir, "images")
+        labels_dir = os.path.join(split_dir, "labels")
         os.makedirs(split_dir, exist_ok=True)
+        os.makedirs(images_dir, exist_ok=True)
+        os.makedirs(labels_dir, exist_ok=True)
 
-        for data_dir_name, conflicting_suffix in [("images", ".png"), ("labels", ".txt")]:
-            data_dir = os.path.join(split_dir, data_dir_name)
-            os.makedirs(data_dir, exist_ok=True)
+        split_img_file_names = [
+            file_name for file_name in os.listdir(images_dir) if file_name.endswith(".png")
+        ]
+        split_label_file_names = [
+            file_name for file_name in os.listdir(labels_dir) if file_name.endswith(".txt")
+        ]
+        split_img_file_names_list.append(split_img_file_names)
+        split_label_file_names_list.append(split_label_file_names)
 
-            conflicting_file_names = [
-                file_name
-                for file_name in os.listdir(data_dir)
-                if file_name.endswith(conflicting_suffix)
-            ]
-            if len(conflicting_file_names) == 0:
-                continue
-
-            if not overwrite:
+        if not overwrite and not resume:
+            if len(split_img_file_names) > 0 or len(split_label_file_names) > 0:
                 return False
-            for conflicting_file_name in conflicting_file_names:
-                os.remove(os.path.join(data_dir, conflicting_file_name))
+        if overwrite:
+            for img_file_name in split_img_file_names:
+                os.remove(os.path.join(images_dir, img_file_name))
+            for label_file_name in split_label_file_names:
+                os.remove(os.path.join(labels_dir, label_file_name))
+
+    file_prefixes = get_common_file_name_prefixes(
+        os.path.join(training_dir, region_id), ignore_names=[BOUNDING_BOXES_VISUALIZATION_FILE_NAME]
+    )
+    if not resume:
+        num_files = len(file_prefixes)
+        train_cutoff = int(num_files * train_fraction)
+        test_cutoff = int(num_files * (train_fraction + test_fraction))
+
+        all_indices = np.arange(num_files)
+        np.random.shuffle(all_indices)
+        train_indices = all_indices[:train_cutoff]
+        test_indices = all_indices[train_cutoff:test_cutoff]
+        val_indices = all_indices[test_cutoff:]
+
+        for split_indices, split_dir_name in zip(
+            [train_indices, test_indices, val_indices], SPLIT_DIR_NAMES
+        ):
+            for i in split_indices:
+                file_prefix = file_prefixes[i]
+                os.symlink(
+                    os.path.join(training_dir, region_id, f"{file_prefix}.png"),
+                    os.path.join(LD_training_dir, split_dir_name, "images", f"{file_prefix}.png"),
+                )
+    else:
+        seen_img_file_prefixes = set()
+        for split_dir_name, split_img_file_names, split_label_file_names in zip(
+            SPLIT_DIR_NAMES, split_img_file_names_list, split_label_file_names_list
+        ):
+            split_img_file_prefixes = {
+                file_name[: -len(".png")] for file_name in split_img_file_names
+            }
+            split_label_file_prefixes = {
+                file_name[: -len(".txt")] for file_name in split_label_file_names
+            }
+            if not (split_label_file_prefixes <= split_img_file_prefixes):
+                raise ValueError(
+                    f"Label files are not a subset of image files for {os.path.join(LD_training_dir, split_dir_name)}"
+                )
+
+            if len(seen_img_file_prefixes & split_img_file_prefixes) > 0:
+                raise ValueError(
+                    f"Duplicate image files found in different splits for {LD_training_dir}"
+                )
+            seen_img_file_prefixes |= split_img_file_prefixes
+
+        if seen_img_file_prefixes != set(file_prefixes):
+            raise ValueError(
+                f"Image files do not match the expected image files for {LD_training_dir}"
+            )
 
     return True
 
@@ -214,29 +318,28 @@ def get_valid_bounding_boxes(
     return valid_bounding_boxes
 
 
-def generate_yolo_labels(
+def generate_yolo_label(
     region_id: str,
-    file_prefixes: List[str],
-    yolo_label_paths: List[str],
+    split_dir_name: str,
+    file_prefix: str,
     pixel_batch_size: int = 1000,
-) -> int:
+) -> None:
     """
-    Generate YOLO labels in the form of .txt files for each image in the input directory.
+    Generate a YOLO label .txt files for the specified region and file prefix.
 
-    Each .txt file contains one line for each bounding box that is entirely contained within the image.
+    The .txt file contains one line for each bounding box that is entirely contained within the image.
     The line is formatted as follows, with all coordinates normalized to the range [0, 1]:
     <class_id> <u_center> <v_center> <box_width> <box_height>
 
     :param region_id: The MGRS region ID to generate YOLO label files for.
-    :param file_prefixes: The common prefixes of the PNG and lat/lon .npy files to process.
-    :param yolo_label_paths: The paths to write the YOLO label files to. Must have the same length as file_prefixes.
+    :param split_dir_name: The name of the split directory that the file prefix belongs to. Must be an element of
+                           SPLIT_DIR_NAMES.
+    :param file_prefix: The common prefix of the PNG and lat/lon .npz files to process and the .txt YOLO label file to
+                        generate.
     :param pixel_batch_size: The number of pixels to process in each batch when finding the closest pixel to each
                              bounding box corner. Smaller values will use less memory but may be slower.
-    :return: The number of classes in the dataset.
     """
-    assert len(file_prefixes) == len(
-        yolo_label_paths
-    ), "file_prefixes and yolo_label_paths must be the same length."
+    assert split_dir_name in SPLIT_DIR_NAMES, f"Invalid split directory name: {split_dir_name}"
 
     training_dir = load_config(USER_CONFIG_PATH)["training_directory"]
     bounding_boxes_lat_lon = LandmarkDetector.load_ground_truth(
@@ -256,180 +359,135 @@ def generate_yolo_labels(
     )
     stacked_corners_ecef = lat_lon_to_ecef(stacked_corners_lat_lon)
 
-    # TODO: upgrade workflow to parallelize this loop with multiprocessing
-    for file_prefix, yolo_label_path in tqdm(
-        zip(file_prefixes, yolo_label_paths),
-        desc=f"Generating labels for {region_id}",
-        total=len(file_prefixes),
-    ):
-        try:
-            geotagged_image = GeotaggedImage.load(region_id, file_prefix)
-        except Exception:
-            print(
-                f"Warning: Failed to load image for: {region_id=}, {file_prefix=}. Skipping generating YOLO label for them."
-            )
-            continue
-
-        height, width = geotagged_image.image.shape[:2]
-        pixel_coordinates_ecef = lat_lon_to_ecef(geotagged_image.lat_lon).reshape(-1, 3)
-
-        closest_pixel_indices = np.empty(4 * num_classes, dtype=int)
-        minimum_distances = np.full(4 * num_classes, np.inf)
-        for start_pixel_idx in range(0, height * width, pixel_batch_size):
-            end_pixel_idx = min(start_pixel_idx + pixel_batch_size, height * width)
-            pixel_slice = slice(start_pixel_idx, end_pixel_idx)
-
-            x_distances = np.subtract.outer(
-                stacked_corners_ecef[:, 0], pixel_coordinates_ecef[pixel_slice, 0]
-            )
-            y_distances = np.subtract.outer(
-                stacked_corners_ecef[:, 1], pixel_coordinates_ecef[pixel_slice, 1]
-            )
-            z_distances = np.subtract.outer(
-                stacked_corners_ecef[:, 2], pixel_coordinates_ecef[pixel_slice, 2]
-            )
-            # surprisingly axis=0 is actually faster than axis=-1 here, probably because of the overhead in
-            # creating the stacked array
-            distances = np.linalg.norm(
-                np.stack((x_distances, y_distances, z_distances), axis=0), axis=0
-            )
-            assert distances.shape == (4 * num_classes, end_pixel_idx - start_pixel_idx)
-
-            batch_closest_pixel_indices = np.argmin(distances, axis=1)
-            batch_minimum_distances = distances[
-                np.arange(4 * num_classes), batch_closest_pixel_indices
-            ]
-
-            closer_mask = batch_minimum_distances < minimum_distances
-            closest_pixel_indices[closer_mask] = (
-                batch_closest_pixel_indices[closer_mask] + start_pixel_idx
-            )
-            minimum_distances[closer_mask] = batch_minimum_distances[closer_mask]
-
-        closest_vs, closest_us = np.unravel_index(closest_pixel_indices, (height, width))
-        closest_us = closest_us.reshape(num_classes, 4)
-        closest_vs = closest_vs.reshape(num_classes, 4)
-
-        valid_bounding_boxes = get_valid_bounding_boxes(
-            geotagged_image.image, closest_us, closest_vs
+    try:
+        geotagged_image = GeotaggedImage.load(region_id, file_prefix)
+    except Exception:
+        print(
+            f"Warning: Failed to load image for: {region_id=}, {file_prefix=}. Skipping generating YOLO label for them."
         )
-        closest_us = closest_us[valid_bounding_boxes, :]
-        closest_vs = closest_vs[valid_bounding_boxes, :]
-        class_ids = np.arange(num_classes)[valid_bounding_boxes]
+        return
 
-        # widen bounding boxes to the smallest axis-aligned bounding box that contains all 4 corners
-        min_us = np.min(closest_us, axis=1)
-        max_us = np.max(closest_us, axis=1)
-        min_vs = np.min(closest_vs, axis=1)
-        max_vs = np.max(closest_vs, axis=1)
+    height, width = geotagged_image.image.shape[:2]
+    pixel_coordinates_ecef = lat_lon_to_ecef(geotagged_image.lat_lon).reshape(-1, 3)
 
-        # convert to YOLO format
-        u_center = (min_us + max_us) / (2 * width)
-        v_center = (min_vs + max_vs) / (2 * height)
-        box_width = (max_us - min_us) / width
-        box_height = (max_vs - min_vs) / height
+    closest_pixel_indices = np.empty(4 * num_classes, dtype=int)
+    minimum_distances = np.full(4 * num_classes, np.inf)
+    for start_pixel_idx in range(0, height * width, pixel_batch_size):
+        end_pixel_idx = min(start_pixel_idx + pixel_batch_size, height * width)
+        pixel_slice = slice(start_pixel_idx, end_pixel_idx)
 
-        with open(yolo_label_path, "w") as yolo_label_file:
-            for class_id, u, v, w, h in zip(class_ids, u_center, v_center, box_width, box_height):
-                yolo_label_file.write(f"{class_id} {u} {v} {w} {h}\n")
+        x_distances = np.subtract.outer(
+            stacked_corners_ecef[:, 0], pixel_coordinates_ecef[pixel_slice, 0]
+        )
+        y_distances = np.subtract.outer(
+            stacked_corners_ecef[:, 1], pixel_coordinates_ecef[pixel_slice, 1]
+        )
+        z_distances = np.subtract.outer(
+            stacked_corners_ecef[:, 2], pixel_coordinates_ecef[pixel_slice, 2]
+        )
+        # surprisingly axis=0 is actually faster than axis=-1 here, probably because of the overhead in
+        # creating the stacked array
+        distances = np.linalg.norm(
+            np.stack((x_distances, y_distances, z_distances), axis=0), axis=0
+        )
+        assert distances.shape == (4 * num_classes, end_pixel_idx - start_pixel_idx)
 
-    return num_classes
+        batch_closest_pixel_indices = np.argmin(distances, axis=1)
+        batch_minimum_distances = distances[np.arange(4 * num_classes), batch_closest_pixel_indices]
 
+        closer_mask = batch_minimum_distances < minimum_distances
+        closest_pixel_indices[closer_mask] = (
+            batch_closest_pixel_indices[closer_mask] + start_pixel_idx
+        )
+        minimum_distances[closer_mask] = batch_minimum_distances[closer_mask]
 
-def prepare_yolo_data_for_region(region_id: str, test_fraction: float, val_fraction: float) -> None:
-    """
-    Prepare YOLO training data for the specified MGRS region.
-    This includes performing a train/test/val split, creating symlinks to the image files, generating the YOLO label
-    .txt files, and creating a dataset.yaml file.
-    All the resulting files are written to the LD_training directory within the specified region's directory.
+    closest_vs, closest_us = np.unravel_index(closest_pixel_indices, (height, width))
+    closest_us = closest_us.reshape(num_classes, 4)
+    closest_vs = closest_vs.reshape(num_classes, 4)
 
-    :param region_id: The MGRS region ID to prepare the YOLO training data for.
-    :param test_fraction: The fraction of images to use for testing. Must be in the range [0, 1].
-    :param val_fraction: The fraction of images to use for validation. Must be in the range [0, 1].
-    """
-    train_fraction = 1 - test_fraction - val_fraction
-    assert 0 <= train_fraction <= 1, "test_fraction + val_fraction must be less than or equal to 1."
-    assert 0 <= test_fraction <= 1, "test_fraction must be in the range [0, 1]."
-    assert 0 <= val_fraction <= 1, "val_fraction must be in the range [0, 1]."
+    valid_bounding_boxes = get_valid_bounding_boxes(geotagged_image.image, closest_us, closest_vs)
+    closest_us = closest_us[valid_bounding_boxes, :]
+    closest_vs = closest_vs[valid_bounding_boxes, :]
+    class_ids = np.arange(num_classes)[valid_bounding_boxes]
 
-    training_dir = load_config(USER_CONFIG_PATH)["training_directory"]
-    region_dir = os.path.join(training_dir, region_id)
-    LD_training_dir = os.path.join(region_dir, LD_TRAINING_DIR_NAME)
-    file_prefixes = get_common_file_name_prefixes(region_dir, ignore_names=[BOUNDING_BOXES_VISUALIZATION_FILE_NAME])
-    if len(file_prefixes) == 0:
-        raise ValueError("No matching PNG and lat/lon files found.")
+    # widen bounding boxes to the smallest axis-aligned bounding box that contains all 4 corners
+    min_us = np.min(closest_us, axis=1)
+    max_us = np.max(closest_us, axis=1)
+    min_vs = np.min(closest_vs, axis=1)
+    max_vs = np.max(closest_vs, axis=1)
 
-    num_files = len(file_prefixes)
-    train_cutoff = int(num_files * train_fraction)
-    test_cutoff = int(num_files * (train_fraction + test_fraction))
+    # convert to YOLO format
+    u_center = (min_us + max_us) / (2 * width)
+    v_center = (min_vs + max_vs) / (2 * height)
+    box_width = (max_us - min_us) / width
+    box_height = (max_vs - min_vs) / height
 
-    all_indices = np.arange(num_files)
-    np.random.shuffle(all_indices)
-    train_indices = all_indices[:train_cutoff]
-    test_indices = all_indices[train_cutoff:test_cutoff]
-    val_indices = all_indices[test_cutoff:]
-
-    yolo_label_paths = [""] * num_files
-    for split_indices, split_dir_name in zip(
-        [train_indices, test_indices, val_indices], ["train", "test", "val"]
-    ):
-        split_dir = os.path.join(LD_training_dir, split_dir_name)
-        images_dir = os.path.join(split_dir, "images")
-        labels_dir = os.path.join(split_dir, "labels")
-
-        for i in split_indices:
-            file_prefix = file_prefixes[i]
-            os.symlink(
-                os.path.join(region_dir, f"{file_prefix}.png"),
-                os.path.join(images_dir, f"{file_prefix}.png"),
-            )
-            yolo_label_paths[i] = os.path.join(labels_dir, f"{file_prefix}.txt")
-
-    assert "" not in yolo_label_paths
-    num_classes = generate_yolo_labels(region_id, file_prefixes, yolo_label_paths)
-
-    yolo_config = {
-        "path": os.path.abspath(LD_training_dir),
-        "train": "train/images",
-        "val": "val/images",
-        "test": "test/images",
-        "nc": num_classes,
-        "names": [str(i) for i in range(num_classes)],
-    }
-
-    yolo_config_path = os.path.join(LD_training_dir, YOLO_CONFIG_FILE_NAME)
-    with open(yolo_config_path, "w", encoding="utf-8") as yolo_config_file:
-        yaml.dump(yolo_config, yolo_config_file, default_flow_style=False)
+    yolo_label_path = os.path.join(
+        training_dir, region_id, LD_TRAINING_DIR_NAME, split_dir_name, "labels", f"{file_prefix}.txt"
+    )
+    with open(yolo_label_path, "w") as yolo_label_file:
+        for class_id, u, v, w, h in zip(class_ids, u_center, v_center, box_width, box_height):
+            yolo_label_file.write(f"{class_id} {u} {v} {w} {h}\n")
 
 
 def main():
     args = parse_args()
+    if args.overwrite and args.resume:
+        raise ValueError("Cannot use --overwrite and --resume at the same time.")
     regions = sorted(set(args.regions) - set(args.skip_regions))
 
     training_dir = load_config(USER_CONFIG_PATH)["training_directory"]
     for region in tqdm(regions, desc="Setting up region directories"):
-        LD_training_dir: str = os.path.join(training_dir, region, LD_TRAINING_DIR_NAME)
-        if not setup_LD_training_directory(LD_training_dir, args.overwrite):
+        if not setup_LD_training_directory(
+            region, args.overwrite, args.resume, args.test_fraction, args.val_fraction
+        ):
             print(
-                f"Output directory {LD_training_dir} could not be emptied. Set --overwrite to clear any existing data."
+                f"Output directory for {region} could not be emptied. Set --overwrite to clear any existing data."
             )
             return
 
-    func = partial(
-        prepare_yolo_data_for_region,
-        test_fraction=args.test_fraction,
-        val_fraction=args.val_fraction,
-    )
+    def get_requests_generator() -> Generator[Tuple[str, str, str], None, None]:
+        """
+        :return: A generator that yields tuples of (region_id, split_dir_name, file_prefix) for each YOLO label file to
+                 be generated.
+        """
+        for region in regions:
+            LD_training_dir = os.path.join(training_dir, region, LD_TRAINING_DIR_NAME)
+            for split_dir_name in SPLIT_DIR_NAMES:
+                split_dir = os.path.join(LD_training_dir, split_dir_name)
+                images_dir = os.path.join(split_dir, "images")
+
+                file_prefixes_generator = (
+                    file_name[: -len(".png")]
+                    for file_name in os.listdir(images_dir)
+                    if file_name.endswith(".png")
+                )
+                if args.resume:
+                    labels_dir = os.path.join(split_dir, "labels")
+                    file_prefixes_generator = (
+                        file_prefix
+                        for file_prefix in file_prefixes_generator
+                        if not os.path.exists(os.path.join(labels_dir, f"{file_prefix}.txt"))
+                    )
+
+                yield from (
+                    (region, split_dir_name, file_prefix) for file_prefix in file_prefixes_generator
+                )
+
     if args.num_processes > 1:
+        total_requests = sum(1 for _ in get_requests_generator())
         with Pool(args.num_processes) as pool:
             list(
                 tqdm(
-                    pool.imap_unordered(func, regions),
+                    pool.imap_unordered(
+                        partial(unpack_and_call, generate_yolo_label), get_requests_generator()
+                    ),
+                    total=total_requests,
                     desc="Generating images",
                 )
             )
     else:
-        list(map(func, regions))
+        list(starmap(generate_yolo_label, get_requests_generator()))
 
 
 if __name__ == "__main__":

--- a/VisionTrainingGround/LD/prepare_yolo_data.py
+++ b/VisionTrainingGround/LD/prepare_yolo_data.py
@@ -5,7 +5,7 @@ This script expects to find the following contents in the training directory:
 - /training_directory
   - /{region}
     - 00000.png
-    - 00000_lat_lon.npy
+    - 00000_lat_lon.npz
     - ...
     - bounding_boxes.csv
 

--- a/VisionTrainingGround/LD/run_saliency_analysis.py
+++ b/VisionTrainingGround/LD/run_saliency_analysis.py
@@ -5,7 +5,7 @@ This script expects to find the following contents in the training directory:
 - /training_directory
   - /{region}
     - 00000.png
-    - 00000_lat_lon.npy
+    - 00000_lat_lon.npz
     - ...
 
 This script will generate/overwrite the following contents in the training directory:


### PR DESCRIPTION
Also modifies the parallelization to be across the YOLO label files being generated as opposed to the regions. This not only allows scaling the number of processes to more than the number of regions, but also ensures that all requests for a given region are dispatched before moving on to the next region. This in turn, enables the first few LD networks to be trained earlier.